### PR TITLE
Check incoming message gateway

### DIFF
--- a/src/main/java/com/selfcoders/matterbukkit/APIClient.java
+++ b/src/main/java/com/selfcoders/matterbukkit/APIClient.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 public class APIClient {
@@ -97,6 +98,11 @@ public class APIClient {
 
         // Skip messages with an empty text property (e.g. in case a picture or file has been sent)
         if (message.getText().isEmpty()) {
+            return;
+        }
+
+        // Check the gateway of received messages so we don't bridge messages from other gateways
+        if (!Objects.equals(message.getGateway(), gateway)) {
             return;
         }
 

--- a/src/main/java/com/selfcoders/matterbukkit/Message.java
+++ b/src/main/java/com/selfcoders/matterbukkit/Message.java
@@ -5,11 +5,13 @@ public class Message {
     private String text;
     private String username;
     private String avatar;
+    private String gateway;
 
-    public Message(String username, String text, String avatar) {
+    public Message(String username, String text, String avatar, String gateway) {
         this.username = username;
         this.text = text;
         this.avatar = avatar;
+        this.gateway = gateway;
     }
 
     public String getEvent() {
@@ -26,5 +28,9 @@ public class Message {
 
     public String getAvatar() {
         return avatar;
+    }
+
+    public String getGateway() {
+        return gateway;
     }
 }


### PR DESCRIPTION
Otherwise, we'll bridge incoming messages for other non-configured gateways, which causes problems for server networks.

If this breaks anyone's workflow, let me know and I'll add a configuration option to revert it to the old behavior.